### PR TITLE
Native iOS files weren't correctly ignored

### DIFF
--- a/MFP_6.3.gitignore
+++ b/MFP_6.3.gitignore
@@ -29,22 +29,22 @@ bin
 # Native iphone/ipad files, adapted from:
 # https://github.com/github/gitignore/blob/master/Objective-C.gitignore
 
-/apps/*/i*/native/build/
-/apps/*/i*/native/*.pbxuser
-!/apps/*/i*/native/default.pbxuser
-/apps/*/i*/native/*.mode1v3
-!/apps/*/i*/native/efault.mode1v3
-/apps/*/i*/native/*.mode2v3
-!/apps/*/i*/native/default.mode2v3
-/apps/*/i*/native/*.perspectivev3
-!/apps/*/i*/native/default.perspectivev3
-/apps/*/i*/native/xcuserdata
-/apps/*/i*/native/*.xccheckout
-/apps/*/i*/native/*.moved-aside
-/apps/*/i*/native/DerivedData
-/apps/*/i*/native/*.hmap
-/apps/*/i*/native/*.ipa
-/apps/*/i*/native/*.xcuserstate
+/apps/*/i*/native/**/build/
+/apps/*/i*/native/**/*.pbxuser
+!/apps/*/i*/native/**/default.pbxuser
+/apps/*/i*/native/**/*.mode1v3
+!/apps/*/i*/native/**/default.mode1v3
+/apps/*/i*/native/**/*.mode2v3
+!/apps/*/i*/native/**/default.mode2v3
+/apps/*/i*/native/**/*.perspectivev3
+!/apps/*/i*/native/**/default.perspectivev3
+/apps/*/i*/native/**/xcuserdata
+/apps/*/i*/native/**/*.xccheckout
+/apps/*/i*/native/**/*.moved-aside
+/apps/*/i*/native/**/DerivedData
+/apps/*/i*/native/**/*.hmap
+/apps/*/i*/native/**/*.ipa
+/apps/*/i*/native/**/*.xcuserstate
 
 # Injected by the command-line tools
 derby.log

--- a/MFP_7.0.gitignore
+++ b/MFP_7.0.gitignore
@@ -32,22 +32,22 @@ bin
 # Native iphone/ipad files, adapted from:
 # https://github.com/github/gitignore/blob/master/Objective-C.gitignore
 
-/apps/*/i*/native/build/
-/apps/*/i*/native/*.pbxuser
-!/apps/*/i*/native/default.pbxuser
-/apps/*/i*/native/*.mode1v3
-!/apps/*/i*/native/efault.mode1v3
-/apps/*/i*/native/*.mode2v3
-!/apps/*/i*/native/default.mode2v3
-/apps/*/i*/native/*.perspectivev3
-!/apps/*/i*/native/default.perspectivev3
-/apps/*/i*/native/xcuserdata
-/apps/*/i*/native/*.xccheckout
-/apps/*/i*/native/*.moved-aside
-/apps/*/i*/native/DerivedData
-/apps/*/i*/native/*.hmap
-/apps/*/i*/native/*.ipa
-/apps/*/i*/native/*.xcuserstate
+/apps/*/i*/native/**/build/
+/apps/*/i*/native/**/*.pbxuser
+!/apps/*/i*/native/**/default.pbxuser
+/apps/*/i*/native/**/*.mode1v3
+!/apps/*/i*/native/**/default.mode1v3
+/apps/*/i*/native/**/*.mode2v3
+!/apps/*/i*/native/**/default.mode2v3
+/apps/*/i*/native/**/*.perspectivev3
+!/apps/*/i*/native/**/default.perspectivev3
+/apps/*/i*/native/**/xcuserdata
+/apps/*/i*/native/**/*.xccheckout
+/apps/*/i*/native/**/*.moved-aside
+/apps/*/i*/native/**/DerivedData
+/apps/*/i*/native/**/*.hmap
+/apps/*/i*/native/**/*.ipa
+/apps/*/i*/native/**/*.xcuserstate
 
 # Injected by the command-line tools
 derby.log

--- a/Worklight_6.1.gitignore
+++ b/Worklight_6.1.gitignore
@@ -30,22 +30,22 @@ bin
 # Native iphone/ipad files, adapted from:
 # https://github.com/github/gitignore/blob/master/Objective-C.gitignore
 
-/apps/*/i*/native/build/
-/apps/*/i*/native/*.pbxuser
-!/apps/*/i*/native/default.pbxuser
-/apps/*/i*/native/*.mode1v3
-!/apps/*/i*/native/efault.mode1v3
-/apps/*/i*/native/*.mode2v3
-!/apps/*/i*/native/default.mode2v3
-/apps/*/i*/native/*.perspectivev3
-!/apps/*/i*/native/default.perspectivev3
-/apps/*/i*/native/xcuserdata
-/apps/*/i*/native/*.xccheckout
-/apps/*/i*/native/*.moved-aside
-/apps/*/i*/native/DerivedData
-/apps/*/i*/native/*.hmap
-/apps/*/i*/native/*.ipa
-/apps/*/i*/native/*.xcuserstate
+/apps/*/i*/native/**/build/
+/apps/*/i*/native/**/*.pbxuser
+!/apps/*/i*/native/**/default.pbxuser
+/apps/*/i*/native/**/*.mode1v3
+!/apps/*/i*/native/**/default.mode1v3
+/apps/*/i*/native/**/*.mode2v3
+!/apps/*/i*/native/**/default.mode2v3
+/apps/*/i*/native/**/*.perspectivev3
+!/apps/*/i*/native/**/default.perspectivev3
+/apps/*/i*/native/**/xcuserdata
+/apps/*/i*/native/**/*.xccheckout
+/apps/*/i*/native/**/*.moved-aside
+/apps/*/i*/native/**/DerivedData
+/apps/*/i*/native/**/*.hmap
+/apps/*/i*/native/**/*.ipa
+/apps/*/i*/native/**/*.xcuserstate
 
 #
 # END mfp-gitignore rules

--- a/Worklight_6.2.gitignore
+++ b/Worklight_6.2.gitignore
@@ -29,22 +29,22 @@ bin
 # Native iphone/ipad files, adapted from:
 # https://github.com/github/gitignore/blob/master/Objective-C.gitignore
 
-/apps/*/i*/native/build/
-/apps/*/i*/native/*.pbxuser
-!/apps/*/i*/native/default.pbxuser
-/apps/*/i*/native/*.mode1v3
-!/apps/*/i*/native/efault.mode1v3
-/apps/*/i*/native/*.mode2v3
-!/apps/*/i*/native/default.mode2v3
-/apps/*/i*/native/*.perspectivev3
-!/apps/*/i*/native/default.perspectivev3
-/apps/*/i*/native/xcuserdata
-/apps/*/i*/native/*.xccheckout
-/apps/*/i*/native/*.moved-aside
-/apps/*/i*/native/DerivedData
-/apps/*/i*/native/*.hmap
-/apps/*/i*/native/*.ipa
-/apps/*/i*/native/*.xcuserstate
+/apps/*/i*/native/**/build/
+/apps/*/i*/native/**/*.pbxuser
+!/apps/*/i*/native/**/default.pbxuser
+/apps/*/i*/native/**/*.mode1v3
+!/apps/*/i*/native/**/default.mode1v3
+/apps/*/i*/native/**/*.mode2v3
+!/apps/*/i*/native/**/default.mode2v3
+/apps/*/i*/native/**/*.perspectivev3
+!/apps/*/i*/native/**/default.perspectivev3
+/apps/*/i*/native/**/xcuserdata
+/apps/*/i*/native/**/*.xccheckout
+/apps/*/i*/native/**/*.moved-aside
+/apps/*/i*/native/**/DerivedData
+/apps/*/i*/native/**/*.hmap
+/apps/*/i*/native/**/*.ipa
+/apps/*/i*/native/**/*.xcuserstate
 
 # Injected by the WL 6.2 command-line tools
 derby.log


### PR DESCRIPTION
We'd adapted from a website, but we hadn't dealt with the fact that Git implies a leading `**` on rules that don't begin with a `/`.  Thus, a lot of our native .gitignore rules weren't matching.